### PR TITLE
Fix string.format calls for Lua 5.1 compatibility

### DIFF
--- a/dist/downloader.lua
+++ b/dist/downloader.lua
@@ -32,7 +32,7 @@ function fetch_pkgs(packages, download_dir, repo_paths)
             return nil, err
         end
 
-        log:info("Downloading '%s'...", pkg)
+        log:info("Downloading '%s'...", tostring(pkg))
 
         -- Search repo_paths for one containing requested package
         local sha = nil

--- a/dist/init.lua
+++ b/dist/init.lua
@@ -113,7 +113,7 @@ local function _remove(package_names)
         end
 
         if found_pkg == nil then
-            log:error("Could not remove package '%s', no records of its installation were found", pkg_name)
+            log:error("Could not remove package '%s', no records of its installation were found", tostring(pkg_name))
         else
             ok, err = mgr.remove_pkg(found_pkg)
             if not ok then


### PR DESCRIPTION
In Lua 5.1, `string.format` does not support printing tables with meta function `__tostring()` defined when using the `%s` format.
And since Lua Logging uses string.format, some calls resulted in errors.
